### PR TITLE
remove line from dockerfile that caused error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR $APP
 COPY Gemfile Gemfile.lock ./
-COPY .bundle $BUNDLE_APP_CONFIG/
 RUN gem install bundler:2.1.4
 RUN bundle install --binstubs
 RUN bundle install


### PR DESCRIPTION
BUG

Problem with docker unable to find .bundle file prompted removal of this functionality.

Issue is common, not easily overcome, the line does not appear to be necessary