### PR TITLE
fix argument in controller

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -58,7 +58,7 @@ class ApiController < ApplicationController
     erb = EndpointRequestBuilder.new(@endpoint)
     erb.validate(@arguments)
     url_path = erb.formatted_url_path(@arguments)
-    extra_params = erb.extra_params(argument_array)
+    extra_params = erb.extra_params(@arguments)
     [url_path, extra_params]
   end
 


### PR DESCRIPTION
this is my fault

I have avoided testing private methods, they are private and use instance variables

there is no excuse other than a desire for expedience

this needs to be addressed, adding controller spect testing as an issue prior to 1.0 release